### PR TITLE
fix backend config

### DIFF
--- a/templates/default/thruk_local.conf.erb
+++ b/templates/default/thruk_local.conf.erb
@@ -27,9 +27,9 @@
 <% end %>
 <% unless node['thruk']['backends'].nil? %>
 
+<Component Thruk::Backend>
 <% node['thruk']['backends'].each do |id,backend| %>
 # <%= id %>
-<Component Thruk::Backend>
     <peer>
         name   = <%= backend['name'] %>
         type   = <%= backend['type'] %>
@@ -48,6 +48,6 @@
        </configtool>
 <% end %>
     </peer>
+<% end %>
+<% end %>
 </Component>
-<% end %>
-<% end %>


### PR DESCRIPTION
All backends definition have to be inside of Thruk::Backend Component block and this block can't be repeated