### PR TITLE
fix foodcritic 053

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,11 @@
 LineLength:
   Max: 999
 
-TrailingComma:
+TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/ConditionalAssignment:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,7 @@ metadata
 
 group :integration do
   cookbook 'fqdn', git: 'https://github.com/drpebcak/fqdn-cookbook.git'
+  cookbook 'curl'
 end
 
 cookbook 'thruk_test', path: 'test/fixtures/cookbooks/thruk_test'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,9 +11,6 @@ depends 'yum-epel'
 depends 'apache2'
 depends 'apt'
 
-# needed for test-kitchen only
-recommends 'curl'
-
 supports 'centos'
 supports 'debian'
 supports 'ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,8 @@ maintainer       'Martha Greenberg'
 maintainer_email 'marthag@mit.edu'
 license          'Apache 2.0'
 description      'Installs/Configures thruk'
+issues_url       'https://github.com/marthag8/cookbook-thruk/issues'
+source_url       'https://github.com/marthag8/cookbook-thruk'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.0'
 


### PR DESCRIPTION
For fix foodcritic 053 i move curl cookbook from metadata to Berksfile integration block
